### PR TITLE
liblock.in: double-quote $@ before invoking subshell

### DIFF
--- a/src/liblock.in
+++ b/src/liblock.in
@@ -30,4 +30,4 @@ if [ -z "$1" ]; then
 	exit 1
 fi
 
-LD_PRELOAD=$LD_PRELOAD:$BASE/lib/@lib@ $@
+LD_PRELOAD=$LD_PRELOAD:$BASE/lib/@lib@ "$@"


### PR DESCRIPTION
This fixes the invocation of programs with quoted parameters, since
'"$@"' preserves the original argument string instead of stripping
one quotation level like '$@' does.

Signed-off-by: Emilio G. Cota <cota@braap.org>