### PR TITLE
Fix LiTL with recent libraries

### DIFF
--- a/src/interpose.c
+++ b/src/interpose.c
@@ -405,7 +405,7 @@ static void *lp_start_routine(void *_arg) {
     return res;
 }
 
-int pthread_create(pthread_t *thread, const pthread_attr_t *attr,
+int __pthread_create(pthread_t *thread, const pthread_attr_t *attr,
                    void *(*start_routine)(void *), void *arg) {
     DEBUG_PTHREAD("[p] pthread_create\n");
     struct routine *r = malloc(sizeof(struct routine));
@@ -415,6 +415,8 @@ int pthread_create(pthread_t *thread, const pthread_attr_t *attr,
 
     return REAL(pthread_create)(thread, attr, lp_start_routine, r);
 }
+__asm__(".symver __pthread_create,pthread_create@@" GLIBC_2_2_5);
+__asm__(".symver __pthread_create,pthread_create@" GLIBC_2_34);
 
 int pthread_mutex_init(pthread_mutex_t *mutex,
                        const pthread_mutexattr_t *attr) {

--- a/src/interpose.h
+++ b/src/interpose.h
@@ -51,7 +51,9 @@
             fprintf(stderr, "WARNING: unable to find symbol: %s.\n", S(name)); \
     } while (0)
 
+#define GLIBC_2_2_5 "GLIBC_2.2.5"
 #define GLIBC_2_3_2 "GLIBC_2.3.2"
+#define GLIBC_2_34 "GLIBC_2.34"
 
 extern int (*REAL(pthread_mutex_init))(pthread_mutex_t *mutex,
                                        const pthread_mutexattr_t *attr);

--- a/src/interpose.map
+++ b/src/interpose.map
@@ -35,3 +35,8 @@ GLIBC_2.3.2 {
       pthread_cond_wait;
       pthread_cond_timedwait;
 } GLIBC_2.2.5;
+
+GLIBC_2.34 {
+   global:
+      pthread_create;
+} GLIBC_2.3.2;

--- a/src/mcstp.c
+++ b/src/mcstp.c
@@ -39,7 +39,7 @@
  * is preempted.
  * Indeed, a thread A can overtake another thread B behind which it has been
  * waiting for a long time.
- * The waiting thread A will first yield its CPU (via pthread_yield) in order to
+ * The waiting thread A will first yield its CPU (via sched_yield) in order to
  * create an opportunity for the preempted thread (lock holder or B) to make
  * progress.
  * If this is not enough, T will overtake the predecessor thread (B) by marking
@@ -144,7 +144,7 @@ int mcs_tp_mutex_trylock(mcs_tp_mutex_t *impl, mcs_tp_node_t *me) {
             goto success;
         } else if (me->status == FAILED) {
             if (GET_TIME() - impl->cs_start_time > MAX_CS_TIME)
-                pthread_yield();
+                sched_yield();
 
             me->last_lock = impl;
             return EBUSY;
@@ -164,7 +164,7 @@ int mcs_tp_mutex_trylock(mcs_tp_mutex_t *impl, mcs_tp_node_t *me) {
             }
 
             if (GET_TIME() - impl->cs_start_time > MAX_CS_TIME)
-                pthread_yield();
+                sched_yield();
 
             me->last_lock = impl;
             return EBUSY;

--- a/src/utils.h
+++ b/src/utils.h
@@ -109,10 +109,6 @@ static inline uint64_t rdtsc(void) {
     return low | ((uint64_t)high) << 32;
 }
 
-static inline int gettid() {
-    return syscall(SYS_gettid);
-}
-
 // EPFL libslock
 #define my_random xorshf96
 #define getticks rdtsc


### PR DESCRIPTION
Fixes: (First commit)
- gettid has been removed from src/utils.c as it is already defined in the C library
- pthread_yield has been renamed sched_yield

Second commit:
Fix the issue described in issue #11. `pthread_create` was not interposed and this resulted in contexts not being initialized.
The fix consists in linking to the new version of `pthread_create` with glibc >= 2.34. Backward compatibility is also assured by linking to the older version of `pthread_create` with glibc < 2.34.